### PR TITLE
Prevent require loopback

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function installFilter(compiler, extension, variant, includeNodeModules) {
             && endsWith(request.path, extension) > 0) {
             
             const altPath = replaceExtension(request.path, extension, ending);
-            if (fs.existsSync(altPath)) {
+            if (fs.existsSync(altPath) && altPath != request.context.issuer) {
                 request.path = altPath;
             }
         }


### PR DESCRIPTION
Add a test to prevent dependencies from importing itself.
## Use case

Admitting webpack plugins are set to: 

``` javascript
plugins: [
    new RequireVariantPlugin(['.js'], '.dev')
]
```

In case we'd like `Module.dev.js` class to extend `Module.js` to override specific methods or add some dev code, requiring Module.js in `Module.dev.js` would instead require itself preventing project to compile.
